### PR TITLE
feat: Provide factory method to setup HttpClient mock with raw JSON content as response

### DIFF
--- a/build/build-ci.yml
+++ b/build/build-ci.yml
@@ -19,7 +19,7 @@ stages:
     jobs:
       - job: Compile_and_test
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DotNetCoreCLI@2
             displayName: 'Build HttpTestUtils solution'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -10,7 +10,8 @@ parameters:
   type: number
 - name: PackagePatchVersion
   type: number
-
+- name: PackagePreview
+  type: boolean
 
 variables:
 - name: Build.Configuration
@@ -44,8 +45,15 @@ stages:
             displayName: 'Set version environment variable'
             inputs:
               targetType: inline
-              script: |
-                Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}"           
+              script: |     
+                $versionSuffix = ""
+                # Double $ before the parameter expression to make sure that the return type is
+                # treated as a boolean.
+                if( $true -eq $${{parameters.PackagePreview}}) {
+                    $versionSuffix = "-beta-$(Build.BuildNumber)"
+                }
+                Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
+
           - task: DotNetCoreCLI@2
             displayName: Package nuget Package
             inputs:
@@ -69,4 +77,4 @@ stages:
               command: push
               packagesToPush: '$(Build.StagingDirectory)/nupkg/*.nupkg'
               nuGetFeedType: external
-              publishFeedCredentials: 'nuget-push-wildcard'
+              publishFeedCredentials: 'nuget-push'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -21,7 +21,7 @@ stages:
     jobs:
       - job: Compile_and_test
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:          
           - task: DotNetCoreCLI@2
             displayName: 'Build HttpTestUtils solution'
@@ -38,7 +38,7 @@ stages:
     jobs:
       - job: Package_and_push
         pool:
-          vmImage: 'ubuntu-16.04'  
+          vmImage: 'ubuntu-latest'  
         steps:
           - task: Powershell@2
             displayName: 'Set version environment variable'

--- a/src/HttpTestUtils/HttpTestUtils.Tests/HttpClientMockTests.cs
+++ b/src/HttpTestUtils/HttpTestUtils.Tests/HttpClientMockTests.cs
@@ -24,6 +24,19 @@ namespace HttpTestUtils.Tests
         }
 
         [Fact]
+        public async Task HttpClientMockReturnsExpectedRawJsonResult()
+        {
+            var sut = HttpClientMock.SetupHttpClientWithRawJsonResponse(
+                HttpStatusCode.Accepted,
+                """{"foo":1,"bar":2}""");
+
+            var response = await sut.GetAsync(new Uri("http://abc.com"));
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            Assert.Equal("""{"foo":1,"bar":2}""", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
         public async Task HttpClientMockReturnsMultipleResults()
         {
             var responses = new[]
@@ -127,7 +140,7 @@ namespace HttpTestUtils.Tests
             var secondRequest = new HttpRequestMessage(HttpMethod.Post, "http://localhost");
             secondRequest.Content = new StringContent("2");
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async ()=> await httpClient.SendAsync(secondRequest));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await httpClient.SendAsync(secondRequest));
         }
 
         private static async Task<T> GetContentFromResponseAsync<T>(HttpResponseMessage response)

--- a/src/HttpTestUtils/HttpTestUtils.Tests/HttpTestUtils.Tests.csproj
+++ b/src/HttpTestUtils/HttpTestUtils.Tests/HttpTestUtils.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
+++ b/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -19,7 +18,7 @@ namespace HttpTestUtils
         public static HttpClient SetupHttpClientWithJsonResponse<TResponseContent>(HttpResponseContent<TResponseContent> response)
         {
             var messageHandler =
-                new TestHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(response.StatusCode) { Content = new StringContent(JsonConvert.SerializeObject(response.Content), Encoding.UTF8, "application/json") }));
+                new TestHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(response.StatusCode) { Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(response.Content), Encoding.UTF8, "application/json") }));
 
             return new HttpClient(messageHandler);
         }
@@ -33,7 +32,7 @@ namespace HttpTestUtils
 
                     var response = new HttpResponseMessage(responseContent.StatusCode)
                     {
-                        Content = new StringContent(JsonConvert.SerializeObject(responseContent.Content),
+                        Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(responseContent.Content),
                                                     Encoding.UTF8,
                                                     "application/json")
                     };
@@ -42,7 +41,15 @@ namespace HttpTestUtils
                 });
 
             return new HttpClient(messageHandler);
-        } 
+        }
+
+        public static HttpClient SetupHttpClientWithRawJsonResponse(HttpStatusCode statusCode, string rawJson)
+        {
+            var messageHandler =
+                new TestHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(statusCode) { Content = new StringContent(rawJson, Encoding.UTF8, "application/json") }));
+
+            return new HttpClient(messageHandler);
+        }
 
         /// <summary>
         /// Sets up a HttpClientMock that will return another response on each invocation.
@@ -65,7 +72,7 @@ namespace HttpTestUtils
 
                     var response = new HttpResponseMessage(responseContent.StatusCode)
                     {
-                        Content = new StringContent(JsonConvert.SerializeObject(responseContent.Content),
+                        Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(responseContent.Content),
                                                     Encoding.UTF8,
                                                     "application/json")
                     };

--- a/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
+++ b/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
@@ -43,6 +43,13 @@ namespace HttpTestUtils
             return new HttpClient(messageHandler);
         }
 
+        /// <summary>
+        /// Sets up a HttpClient mock that will return the specified <paramref name="statusCode"/> and the response-content contains
+        /// the specified <paramref name="rawJson"/> string.
+        /// </summary>
+        /// <param name="statusCode"></param>
+        /// <param name="rawJson"></param>
+        /// <returns>A HttpClient that returns a HttpResponseMessage with the pre-defined status-code and content.</returns>
         public static HttpClient SetupHttpClientWithRawJsonResponse(HttpStatusCode statusCode, string rawJson)
         {
             var messageHandler =
@@ -52,7 +59,7 @@ namespace HttpTestUtils
         }
 
         /// <summary>
-        /// Sets up a HttpClientMock that will return another response on each invocation.
+        /// Sets up a HttpClient mock that will return another response on each invocation.
         /// </summary>
         /// <remarks>The HttpClient will return the responses in the same order as they appear in the <paramref name="responses"/> parameter.</remarks>
         /// <returns>A HttpClient instance that can be used for test purposes.</returns>

--- a/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
+++ b/src/HttpTestUtils/HttpTestUtils/HttpClientMock.cs
@@ -83,7 +83,7 @@ namespace HttpTestUtils
             return new HttpClient(messageHandler);
         }
 
-        private class TestHttpMessageHandler : HttpMessageHandler
+        private sealed class TestHttpMessageHandler : HttpMessageHandler
         {
             private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _createResponseFunction;
 

--- a/src/HttpTestUtils/HttpTestUtils/HttpTestUtils.csproj
+++ b/src/HttpTestUtils/HttpTestUtils/HttpTestUtils.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The new factory method allows to specify a HttpClient mock that returns a specified raw JSON content string.
Additionally, Newtonsoft.Json is no longer used as JSON library; instead System.Text.Json is being used.